### PR TITLE
ci: start workflows on pull request.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint with Ruff
 
-on: [push, pull_request, workflow_call]
+on:
+  pull_request:
+    branches: [main]
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Run Unit Test with Pytest
 
-on: [push, pull_request, workflow_call]
+on:
+  pull_request:
+    branches: [main]
+  workflow_call:
 
 jobs:
   test:


### PR DESCRIPTION
- Trigger workflows only on pull request to main.
- New branch protection rules prevent pushes to main.