### PR TITLE
Ci/prevent redundant workflow runs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint with Ruff
+name: Lint
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint:
-    name: Lint
+    name: Lint (Ruff)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint:
-    name: Lint (Ruff)
+    name: ruff
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,8 @@ on:
       - main
 
 jobs:
-  test:
-    uses: ./.github/workflows/test.yml
-  lint:
-    uses: ./.github/workflows/lint.yml
   release:
     name: Release
-    needs: [test, lint]
     runs-on: ubuntu-latest
     concurrency: release
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Unit Test with Pytest
+name: Unit tests
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Test via pytest
+    name: Unit tests (pytest)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Unit tests (pytest)
+    name: pytest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Lint and test workflows were running twice, but only once is necessary.
1. When a pull request was submitted, to verify that it was okay to merge into main.
2. After a pull request was merged, as a check before building and releasing the next version of the package on PyPi.

The second run is unnecessary, as the first set of runs ensures that the second set will always pass. This PR removes the second set of runs.