### PR TITLE
fix(phase_transition): dimensions back to front.

### DIFF
--- a/pykp/metrics.py
+++ b/pykp/metrics.py
@@ -41,12 +41,12 @@ def _initialise_grid(
         The first array corresponds to normalised capacities, and the second
         to normalised profits.
     """
-    norm_c_step_size = 1 / resolution[0]
-    norm_p_step_size = 1 / resolution[1]
+    norm_c_step_size = 1 / resolution[1]
+    norm_p_step_size = 1 / resolution[0]
 
     grid = np.meshgrid(
-        np.linspace(0, 1 - norm_c_step_size, resolution[0]),
-        np.linspace(1 - norm_p_step_size, 0, resolution[1]),
+        np.linspace(0, 1 - norm_c_step_size, resolution[1]),
+        np.linspace(1 - norm_p_step_size, 0, resolution[0]),
     )
 
     return grid
@@ -218,9 +218,10 @@ def phase_transition(
 
     Returns
     -------
-        grid : tuple of np.ndarray
-            The mesh grid for normalszed capacities (x-axis) and profits
-            (y-axis).
+        coordinate_matrices : tuple of np.ndarray
+            The coordinate matrices for normalised capacities and normalised
+            profits. The first matrix corresponds to normalised capacities,
+            and the second to normalised profits.
         phase_transition : np.ndarray
             A 2D matrix of solvability (ranging from 0.0 to 1.0) corresponding
             to each cell in `grid`.
@@ -233,7 +234,7 @@ def phase_transition(
     resolution: tuple[int, int], optional
         Resolution of the normalised capacity-normalised profit grid.
         The first element corresponds to the resolution of normalised
-        capacity, and the second to the resolution of normalised profit.
+        profit, and the second to the resolution of normalised capacity.
         Defaults to (41, 41).
     path (str, optional): Path to save the phase transition to. Defaults
         to None.
@@ -323,9 +324,7 @@ def phase_transition(
             )
             phase_transition.append(solvability)
 
-    phase_transition = np.array(phase_transition).reshape(
-        (resolution[0], resolution[1])
-    )
+    phase_transition = np.array(phase_transition).reshape(resolution)
 
     if path:
         _save_phase_transition(phase_transition, grid, path)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -22,8 +22,10 @@ def test_phase_transition_returns_correct_shape(resolution):
         resolution=resolution,
         path=None,
     )
-    assert grid[0].shape == (resolution[1], resolution[0])
-    assert grid[1].shape == (resolution[1], resolution[0])
+    # The expected resolution is switched since we want the nc to vary across
+    # the x-axis (columns) and np to vary across the y-axis (rows)
+    assert grid[0].shape == resolution
+    assert grid[1].shape == resolution
 
     assert solvability_matrix.shape == resolution
 


### PR DESCRIPTION
The final `phase_transition` array was being reshaped in a manner that was inconsistent with the way in which  resolution was passed to the function. The expected outcome should be to reshape the phase transition in such a way that nc varies along the x-axis (column-wise) and np along the y-axis (row-wise).