### PR TITLE
Feat/sampler range nc

### DIFF
--- a/pykp/sampler.py
+++ b/pykp/sampler.py
@@ -108,6 +108,11 @@ class Sampler:
         value_dist_kwargs: dict | None = None,
     ):
         self.num_items = num_items
+
+        if normalised_capacity <= 0 or normalised_capacity > 1:
+            raise ValueError(
+                "`normalised_capacity` must be in the interval (0, 1)."
+            )
         self.normalised_capacity = normalised_capacity
 
         if weight_dist != "uniform" and weight_dist_kwargs is None:

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -130,3 +130,12 @@ def test_sample_reporducible(seed: int):
     assert np.array_equal(values, values2)
     assert np.array_equal(weights, weights2)
     assert np.array_equal(knapsack.state, knapsack2.state)
+
+
+def test_non_unit_inverval_nc_raises_error():
+    """Test that non-unit interval normalised capacities raise an error."""
+    with pytest.raises(ValueError):
+        Sampler(num_items=5, normalised_capacity=1.1)
+
+    with pytest.raises(ValueError):
+        Sampler(num_items=5, normalised_capacity=-0.1)


### PR DESCRIPTION
- `pykp.sampler.Sampler` now accepts a `tuple` for `normalised_capacity` to specify the bounds for uniform random sampling.
- Added tests to validate normalised capacity inputs are between [0, 1].